### PR TITLE
Add smooth bpm providier functionality to TempestStroke.

### DIFF
--- a/src/behaviors/tempest-stroke.js
+++ b/src/behaviors/tempest-stroke.js
@@ -30,7 +30,7 @@ class TempestStroke extends AyvaBehavior {
     return this.#bpm;
   }
 
-  static #granularity = 12;
+  static #granularity = 36;
 
   /**
    * How many slices to divide a stroke (180 degrees) into.
@@ -114,13 +114,15 @@ class TempestStroke extends AyvaBehavior {
   }
 
   generateActions () {
-    this.queueFunction((behavior) => {
-      const { granularity } = TempestStroke;
+    const { granularity } = TempestStroke;
 
-      for (let i = granularity - 1; i >= 0; i--) {
+    for (let i = 0; i < granularity; i++) {
+      this.queueFunction((behavior) => {
         this.#createMoves(behavior, i);
-      }
+      });
+    }
 
+    this.queueFunction(() => {
       this.#angle += Math.PI;
     });
   }

--- a/test/behaviors/tempest-stroke.test.js
+++ b/test/behaviors/tempest-stroke.test.js
@@ -11,11 +11,12 @@ describe('Tempest Stroke Tests', function () {
   let ayva;
 
   const performTempestStroke = async function (stroke) {
-    await stroke.perform(ayva); // Generate
-
     for (let i = 0; i < TempestStroke.granularity; i++) {
-      await stroke.perform(ayva); // Perform
+      await stroke.perform(ayva); // Generate Slice
+      await stroke.perform(ayva); // Perform Slice
     }
+
+    await stroke.perform(ayva); // Update Angle
   };
 
   beforeEach(function () {
@@ -148,8 +149,7 @@ describe('Tempest Stroke Tests', function () {
     for (let i = 0; i < strokes.length; i++) {
       const motion = new TempestStroke(strokes[i]);
 
-      await motion.perform(ayva); // Generate
-      await motion.perform(ayva); // Perform
+      await performTempestStroke(motion);
 
       motion.angle.should.equal(Math.PI);
       motion.bpm.should.equal(60);


### PR DESCRIPTION
+Update default granularity to 36.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing.
- [x] 100% code coverage is maintained

If adding a **new feature**, the PR's description includes:
- [x] Reason for adding this feature

**Other information:**
Allow more real time updates to bpm on TempestStrokes by not generating all the moves at once. Fixes issue in Ayva Stroker Lite where changing bpm slider does not update bpm until stroke is finished.
