### PR TITLE
Default value enhancements.

### DIFF
--- a/src/ayva.js
+++ b/src/ayva.js
@@ -481,6 +481,10 @@ class Ayva {
       get: () => this.#axes[axis].lastValue,
     });
 
+    Object.defineProperty(this.$[axis], 'defaultValue', {
+      get: () => this.#axes[axis].defaultValue,
+    });
+
     Object.defineProperty(this.$[axis], 'min', {
       get: () => this.#axes[axis].min,
     });

--- a/src/ayva.js
+++ b/src/ayva.js
@@ -212,16 +212,25 @@ class Ayva {
   }
 
   /**
-   * Moves all linear and rotation axes to their neutral positions.
+   * Moves all axes to their default positions.
    *
-   * @param {Number} [to = 0.5] - optional target position to home to.
    * @param {Number} [speed = 0.5] - optional speed of the movement.
    * @return {Promise} A promise that resolves when the movements are finished.
    */
-  async home (to = 0.5, speed = 0.5) {
+  async home (speed = 0.5) {
     const movements = this.#getAxesArray()
-      .filter((axis) => axis.type === 'linear' || axis.type === 'rotation')
-      .map((axis) => ({ to, speed, axis: axis.name }));
+      .map((axis) => {
+        const movement = {
+          axis: axis.name,
+          to: axis.defaultValue,
+        };
+
+        if (axis.type !== 'boolean') {
+          movement.speed = speed;
+        }
+
+        return movement;
+      });
 
     if (movements.length) {
       return this.move(...movements);

--- a/src/ayva.js
+++ b/src/ayva.js
@@ -347,6 +347,24 @@ class Ayva {
   }
 
   /**
+   * Fetch an array of the axes.
+   */
+  getAxes () {
+    return this.#getAxesArray().map((axis) => ({
+      // Ghetto deep copy, but its the most optimal.
+      name: axis.name,
+      alias: axis.alias,
+      type: axis.type,
+      defaultValue: axis.defaultValue,
+      max: axis.max,
+      min: axis.min,
+      value: axis.value,
+      lastValue: axis.lastValue,
+      resetOnStop: axis.resetOnStop,
+    }));
+  }
+
+  /**
    * Update the limits for the specified axis.
    *
    * @param {String} axis

--- a/src/ayva.js
+++ b/src/ayva.js
@@ -238,6 +238,12 @@ class Ayva {
     this.#currentBehaviorId = null;
     this.#movements.clear();
     this.#sleepResolves.forEach((resolve) => resolve());
+
+    this.#getAxesArray().forEach((axis) => {
+      if (axis.resetOnStop) {
+        this.$[axis.name].value = axis.defaultValue;
+      }
+    });
   }
 
   /**

--- a/src/util/osr-config.js
+++ b/src/util/osr-config.js
@@ -48,16 +48,19 @@ export default {
       name: 'A2',
       alias: 'lube',
       type: 'auxiliary',
+      resetOnStop: true,
     },
     {
       name: 'V0',
       alias: 'vibe0',
       type: 'auxiliary',
+      resetOnStop: true,
     },
     {
       name: 'V1',
       alias: 'vibe1',
       type: 'auxiliary',
+      resetOnStop: true,
     },
   ],
 };

--- a/src/util/validator.js
+++ b/src/util/validator.js
@@ -180,6 +180,26 @@ export default {
       }
     });
 
+    let { defaultValue } = axisConfig;
+
+    if (defaultValue !== undefined && defaultValue !== null) {
+      // Validate user supplied default value.
+      if (axisConfig.type === 'boolean') {
+        if (typeof defaultValue !== 'boolean') {
+          invalid.push('defaultValue');
+        }
+      } else if (!Number.isFinite(defaultValue) || defaultValue < 0 || defaultValue > 1) {
+        invalid.push('defaultValue');
+      }
+    } else if (axisConfig.type === 'boolean') {
+      defaultValue = false;
+    } else if (axisConfig.type === 'auxiliary') {
+      defaultValue = 0;
+    } else {
+      // 0.5 is home position for linear and rotation axes.
+      defaultValue = 0.5;
+    }
+
     if (invalid.length) {
       const message = invalid.sort().map((property) => `${property} = ${axisConfig[property]}`).join(', ');
       fail(`Invalid configuration parameter(s): ${message}`);
@@ -189,19 +209,9 @@ export default {
       fail(`Invalid type. Must be linear, rotation, auxiliary, or boolean: ${axisConfig.type}`);
     }
 
-    let defaultValue;
-
-    if (axisConfig.type === 'boolean') {
-      defaultValue = false;
-    } else if (axisConfig.type === 'auxiliary') {
-      defaultValue = 0;
-    } else {
-      // 0.5 is home position for linear and rotation axes.
-      defaultValue = 0.5;
-    }
-
     const resultConfig = {
       ...axisConfig,
+      defaultValue,
       max: axisConfig.max || 1,
       min: axisConfig.min || 0,
       value: defaultValue,

--- a/test/ayva/ayva.motion.api.test.js
+++ b/test/ayva/ayva.motion.api.test.js
@@ -994,5 +994,33 @@ describe('Motion API Tests', function () {
       ayva.getAxis('R0').value.should.equal(0.500);
       ayva.getAxis('A0').value.should.equal(0.000);
     });
+
+    it('should reset axes configured with resetOnStop = true', async function () {
+      ayva.configureAxis({
+        name: 'V0',
+        type: 'auxiliary',
+        alias: 'vibe0',
+        resetOnStop: true,
+      });
+
+      ayva.getAxis('L0').value.should.equal(0.5);
+      ayva.getAxis('V0').value.should.equal(0);
+
+      const promise = ayva.move(
+        { axis: 'L0', to: 0, duration: 0.1 },
+        { axis: 'V0', to: 0.5 }
+      );
+
+      ayva.stop();
+
+      const result = await promise;
+
+      expect(result).to.equal(false);
+
+      validateWriteOutput('L04000 V01000', 'V00000');
+
+      ayva.getAxis('L0').value.should.equal(0.4);
+      ayva.getAxis('V0').value.should.equal(0);
+    });
   });
 });

--- a/test/ayva/ayva.motion.api.test.js
+++ b/test/ayva/ayva.motion.api.test.js
@@ -70,13 +70,27 @@ describe('Motion API Tests', function () {
       move.callCount.should.equal(1);
 
       const { args } = move.getCall(0);
-      const expectedParams = { to: 0.5, speed: 0.5 };
-      const expectedAxes = ['L0', 'L1', 'L2', 'R0', 'R1', 'R2'];
+      const expectedArgs = ['L0', 'L1', 'L2', 'R0', 'R1', 'R2'].map((axis) => ({
+        // Linear and Rotation axes default to 0.5.
+        axis,
+        to: 0.5,
+        speed: 0.5,
+      }));
 
-      args.length.should.equal(expectedAxes.length);
-      expectedAxes.forEach((axis, index) => {
-        args[index].should.deep.equal({ axis, ...expectedParams });
-      });
+      expectedArgs.unshift(...['B1', 'B2'].map((axis) => ({
+        // Boolean axes default to false.
+        axis,
+        to: false,
+      })));
+
+      expectedArgs.unshift(...['A0', 'A1'].map((axis) => ({
+        // Auxiliary axes default to 0.
+        axis,
+        to: 0,
+        speed: 0.5,
+      })));
+
+      args.should.deep.equal(expectedArgs);
     });
 
     it('should emit a warning when no linear or rotation axes are configured', function () {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
The ```TempestStroke``` method ```getTransitionMoves()``` (*deprecated in 0.11.0*) is now removed. Use ```getStartMoves()``` instead.

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing.
- [x] 100% code coverage is maintained

If adding a **new feature**, the PR's description includes:
- [x] Reason for adding this feature
Prevent axes such as vibe and lube from staying on after a stop or transition.

**Other information:**
